### PR TITLE
Use urllib.parse.unquote now we're on Python 3

### DIFF
--- a/ckanext/tiledmap/routes/_helpers.py
+++ b/ckanext/tiledmap/routes/_helpers.py
@@ -321,13 +321,15 @@ def extract_q_and_filters():
     q = None if 'q' not in toolkit.request.params else unquote(toolkit.request.params['q'])
 
     # pull out the filters if there are any
-    filters = defaultdict(list)
     filter_param = toolkit.request.params.get('filters', None)
     if filter_param:
+        filters = defaultdict(list)
         for field_and_value in unquote(filter_param).split('|'):
             if ':' in field_and_value:
                 field, value = field_and_value.split(':', 1)
                 filters[field].append(value)
+    else:
+        filters = None
 
     return q, filters
 

--- a/ckanext/tiledmap/routes/_helpers.py
+++ b/ckanext/tiledmap/routes/_helpers.py
@@ -4,15 +4,13 @@
 # This file is part of ckanext-versioned-tiledmap
 # Created by the Natural History Museum in London, UK
 
-import gzip
-from collections import defaultdict
-from pathlib import Path
-
 import base64
+import gzip
 import json
-import urllib
+from collections import defaultdict
+from urllib.parse import unquote
+
 from ckan.common import json
-from ckan.lib.render import find_template
 from ckan.plugins import toolkit
 from ckanext.tiledmap.config import config
 
@@ -320,13 +318,13 @@ def extract_q_and_filters():
     :return: a 2-tuple of the q value (string, or None) and the filters value (dict, or None)
     '''
     # get the query if there is one
-    q = None if 'q' not in toolkit.request.params else urllib.unquote(toolkit.request.params['q'])
+    q = None if 'q' not in toolkit.request.params else unquote(toolkit.request.params['q'])
 
     # pull out the filters if there are any
     filters = defaultdict(list)
     filter_param = toolkit.request.params.get('filters', None)
     if filter_param:
-        for field_and_value in urllib.unquote(filter_param).split('|'):
+        for field_and_value in unquote(filter_param).split('|'):
             if ':' in field_and_value:
                 field, value = field_and_value.split(':', 1)
                 filters[field].append(value)

--- a/tests/test_route_helpers.py
+++ b/tests/test_route_helpers.py
@@ -1,0 +1,56 @@
+from functools import wraps
+from unittest.mock import patch, MagicMock
+
+from ckanext.tiledmap.routes._helpers import extract_q_and_filters
+
+
+def mock_params(q=None, filters=None):
+    def decorator(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            params = {}
+            if q is not None:
+                params['q'] = q
+            if filters is not None:
+                params['filters'] = filters
+
+            mock_toolkit = MagicMock(request=MagicMock(params=params))
+
+            with patch('ckanext.tiledmap.routes._helpers.toolkit', mock_toolkit):
+                return f(*args, **kwargs)
+
+        return wrapper
+    return decorator
+
+
+class TestExtractQAndFilters:
+
+    @mock_params()
+    def test_missing_both(self):
+        q, filters = extract_q_and_filters()
+        assert q is None
+        assert filters is None
+
+    @mock_params(q='beans')
+    def test_only_q(self):
+        q, filters = extract_q_and_filters()
+        assert q == 'beans'
+        assert filters is None
+
+    @mock_params(filters='colour:green')
+    def test_only_filters(self):
+        q, filters = extract_q_and_filters()
+        assert q is None
+        assert filters == {'colour': ['green']}
+
+    @mock_params(filters='colour:green|colour:red|food:banana|colour:orange')
+    def test_multiple_filters(self):
+        q, filters = extract_q_and_filters()
+        assert q is None
+        assert filters == {'colour': ['green', 'red', 'orange'], 'food': ['banana']}
+
+    @mock_params(q='beans and cake', filters='colour:green|colour:red|food:banana|colour:orange')
+    def test_both(self):
+        q, filters = extract_q_and_filters()
+        assert q == 'beans and cake'
+        assert filters == {'colour': ['green', 'red', 'orange'], 'food': ['banana']}


### PR DESCRIPTION
This was missed during Python 2 - Python 3 upgrade.

```
2021-06-30 11:14:32,298 ERROR [ckan.config.middleware.flask_app] module 'urllib' has no attribute 'unquote'
Traceback (most recent call last):
  File "/usr/lib/ckan/default/lib/python3.8/site-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib/ckan/default/lib/python3.8/site-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/lib/ckan/default/src/ckanext-versioned-tiledmap/ckanext/tiledmap/routes/map.py", line 29, in info
    return jsonify(view_settings.create_map_info())
  File "/usr/lib/ckan/default/src/ckanext-versioned-tiledmap/ckanext/tiledmap/routes/_helpers.py", line 213, in create_map_info
    map_info['query_body'] = self.get_query_body()
  File "/usr/lib/ckan/default/src/ckanext-versioned-tiledmap/ckanext/tiledmap/routes/_helpers.py", line 193, in get_query_body
    q, filters = extract_q_and_filters()
  File "/usr/lib/ckan/default/src/ckanext-versioned-tiledmap/ckanext/tiledmap/routes/_helpers.py", line 329, in extract_q_and_filters
    for field_and_value in urllib.unquote(filter_param).split('|'):
AttributeError: module 'urllib' has no attribute 'unquote'
```